### PR TITLE
chore(ci): pin GitHub actions and add Go version lookup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      golangci-lint: #
+        patterns:
+          - "golangci*"
+      ci:
+        patterns:
+          - "*"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,16 +18,25 @@ concurrency:
 permissions: read-all
 
 jobs:
+  GoVersions:
+    name: Lookup Go versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
+      - uses: arnested/go-version-action@81f730770833dd20e6365d535ce7efcb3b136e7d #v1.1.21
+        id: versions
+
   UnitTestJob:
     runs-on: ubuntu-latest
+    needs: GoVersions
     strategy:
       matrix:
-        go:
-          - 'oldstable'
-          - 'stable'
+        go: ${{ fromJSON(needs.GoVersions.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5 # immutable action, safe to use the versions
+        uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
       - name: Install Go
         uses: actions/setup-go@v5.2.0 # immutable action, safe to use the versions
         with:
@@ -44,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5 # immutable action
+        uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
 
       - name: Install Go
-        uses: actions/setup-go@v5.2.0 # immutable action
+        uses: actions/setup-go@v5.2.0 # immutable action, safe to use the versions
         with:
           go-version: 'stable'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,10 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.2.0 # immutable action, safe to use the versions
         with:
           go-version: 'stable'
 
@@ -33,20 +33,20 @@ jobs:
         run: sudo docker run --privileged linuxkit/binfmt:v0.8
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: sv-tools-bot
           password: ${{ secrets.BOT_TOKEN }}
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: svtools
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: release --rm-dist --config .github/goreleaser-cli.yml

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ The template for new go repository.
 
 1. MIT License by default
 2. GitHub Action workflows:
-   1. testing all pull requests by running same tools for stable and previous Go version and checking code coverage using `codecov` action
-   2. checking code quality by running `golangci-lint` action
-   3. making a new release by running `goreleaser` action when a new tag is pushed
+    1. testing all pull requests by running same tools for stable and previous Go version and checking code coverage
+       using `codecov` action
+    2. checking code quality by running `golangci-lint` action
+    3. making a new release by running `goreleaser` action when a new tag is pushed
 
 ## Usage
 


### PR DESCRIPTION
Pin reusable GitHub Action references to immutable revisions and
clarify versions in workflow files to improve CI reproducibility and
security. Add a new GoVersions job that queries available Go versions
and exposes a matrix for the UnitTestJob so tests run against the
actual oldstable/stable set discovered at runtime. Also reflow a README
line for consistent wrapping.

Why:
- Immutable action pins prevent accidental behavior changes when
  upstream actions are updated.
- Dynamic Go matrix ensures the test matrix reflects current supported
  Go versions without hardcoding them into the workflow.
- Minor README reflow improves readability.